### PR TITLE
use expose rather than port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,12 @@ services:
             MYSQL_ROOT_PASSWORD: root
     redis:
         image: redis:alpine
-        ports:
-            - 6379:6379
+        expose:
+            - 6379
     php:
         build: php7-fpm
-        ports:
-            - 9000:9000
+        expose:
+            - 9000
         links:
             - db:mysqldb
             - redis


### PR DESCRIPTION
issue : Bind for 0.0.0.0:9000 failed: port is already allocated ERROR: Encountered errors while bringing up the project. It's useless to expose port 9000 to to host machine for php fpm & redis.
